### PR TITLE
we dont need Ad's URL as pointer

### DIFF
--- a/ad.go
+++ b/ad.go
@@ -7,7 +7,7 @@ import "encoding/xml"
 type CommonAd struct {
 	Type                string            `xml:"xsi:type,attr,omitempty"`
 	ID                  int64             `xml:"id,omitempty"`
-	URL                 *string            `xml:"url"`
+	URL                 string            `xml:"url,omitempty"`
 	DisplayURL          string            `xml:"displayUrl,omitempty"`
 	FinalURLs           []string          `xml:"finalUrls,omitempty"`
 	FinalMobileURLs     []string          `xml:"finalMobileUrls,omitempty"`


### PR DESCRIPTION
as we can't SET an Ad (it is immutable) so we never need to send the value empty string
and it makes the code more complex for no advantages
